### PR TITLE
Bump versionNum to 12 for internal test release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ default_platform :android
 
 platform :android do
 
-    versionNum = 11
+    versionNum = 12
 
     before_all do
     end


### PR DESCRIPTION
## Summary
- Bumps `versionNum` from 11 to 12 in `fastlane/Fastfile` (version code `1000012`, version name `1.0.12`).
- Version code `1000011` (versionNum 11) was already published on the internal and production tracks, so a new Play Store upload required a higher code.

## Test plan
- [x] `fastlane deployInternalTest` built a signed release AAB and uploaded it to the Play Store **internal** track successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)