### PR TITLE
Fix back gesture closing the app + bump to version 13

### DIFF
--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/BikeShareContent.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/BikeShareContent.kt
@@ -51,7 +51,11 @@ fun BikeShareApp(circuit: Circuit) {
         colorScheme = colorScheme
     ) {
         val backStack = rememberSaveableBackStack(root = CountryListScreen)
-        val navigator = rememberCircuitNavigator(backStack) {}
+        val navigator = rememberCircuitNavigator(
+            backStack = backStack,
+            onRootPop = {},
+            enableBackHandler = true,
+        )
 
         CircuitCompositionLocals(circuit) {
             NavigableCircuitContent(navigator = navigator, backStack = backStack)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ default_platform :android
 
 platform :android do
 
-    versionNum = 11
+    versionNum = 13
 
     before_all do
     end


### PR DESCRIPTION
## Summary
- **Fixes back navigation:** the Circuit navigator in `BikeShareContent.kt` was created via the `rememberCircuitNavigator(backStack, onRootPop)` overload, which installs no back handler. The system back gesture therefore fell through to the platform default and finished the activity, closing the app instead of popping the Circuit back stack. Switched to the overload with `enableBackHandler = true`, which wires a `NavigationBackHandler` calling `navigator.pop()`. Shared Compose Multiplatform code, so it fixes back handling on all targets.
- **Bumps `versionNum` 11 → 13** for the internal-test release (12 was already published).

## Test plan
- [x] `:androidApp:assembleDebug` compiles.
- [x] `fastlane deployInternalTest` uploaded version code `1000013` to the Play **internal** track.
- [ ] Confirm on device: swiping back navigates to the previous screen instead of closing the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)