### PR TITLE
Simplify promoteAppToProd lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -104,8 +104,7 @@ platform :android do
             skip_upload_apk: true,
             skip_upload_metadata: true,
             skip_upload_images: true,
-            skip_upload_screenshots: true,
-            version_code: 1000013
+            skip_upload_screenshots: true
         )
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -94,7 +94,7 @@ platform :android do
     end
 
 
-    desc "Promote app from alpha to production in Play Store"
+    desc "Promote app from internal to production in Play Store"
     lane :promoteAppToProd do |options|
 
         supply(
@@ -105,7 +105,7 @@ platform :android do
             skip_upload_metadata: true,
             skip_upload_images: true,
             skip_upload_screenshots: true,
-            version_code: 1001086
+            version_code: 1000013
         )
     end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -61,7 +61,7 @@ Deploy app to play store alpha channel
 [bundle exec] fastlane android promoteAppToProd
 ```
 
-Promote app from alpha to production in Play Store
+Promote app from internal to production in Play Store
 
 ### android screenshots
 


### PR DESCRIPTION
## Summary
- Removes the stale hardcoded `version_code` from `promoteAppToProd`. With `track_promote_to` set, `supply` promotes the highest version code on the source (internal) track, so an explicit version_code isn't needed — and it only went stale each release (was `1001086`, an old versioning scheme no longer on any track).
- Fixes the lane description (internal → production, not alpha) and regenerates `fastlane/README.md`.

## Test plan
- [x] `fastlane promoteAppToProd` (run with the corrected version_code) promoted internal `1000013` to production; production now serves `1000013`.
- Going forward the lane auto-selects the latest internal build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)